### PR TITLE
Support PEP 584

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -46,6 +46,23 @@ class immutabledict(Mapping):
             self._hash = h
         return self._hash
 
+    def __or__(self, other):
+        if not isinstance(other, (dict, self.__class__)):
+            return NotImplemented
+        new = dict(self)
+        new.update(other)
+        return self.__class__(new)
+
+    def __ror__(self, other):
+        if not isinstance(other, (dict, self.__class__)):
+            return NotImplemented
+        new = dict(other)
+        new.update(self)
+        return new
+
+    def __ior__(self, other):
+        raise TypeError("'%s' object is not mutable", self.__class__.__name__)
+
 
 class ImmutableOrderedDict(immutabledict):
     """

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -110,6 +110,15 @@ class TestImmutableDict:
         assert first_dict == {"a": "a", "b": "b"}
         assert second_dict == {"a": "A", "c": "c"}
 
+    def test_union_operator_merge_fail(self):
+        first_dict = immutabledict({"a": "a", "b": "b"})
+
+        with pytest.raises(TypeError):
+            first_dict | 0
+
+        with pytest.raises(TypeError):
+            0 | first_dict
+
     def test_union_operator_update(self):
         first_dict = immutabledict({"a": "a", "b": "b"})
         second_dict = immutabledict({"a": "A", "c": "c"})

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -73,18 +73,71 @@ class TestImmutableDict:
         assert hash(first_dict) == hash(second_dict)
 
     def test_union_operator_merge(self):
-        first_dict = immutabledict({"a": "value", "b": "other_value"})
-        second_dict = immutabledict({"a": "value", "b": "other_value"})
+        first_dict = immutabledict({"a": "a", "b": "b"})
+        second_dict = immutabledict({"a": "A", "c": "c"})
+        merged_dict = first_dict | second_dict
+        assert isinstance(merged_dict, immutabledict)
+        assert merged_dict == {
+            "a": "A",
+            "b": "b",
+            "c": "c",
+        }
+        assert first_dict == {"a": "a", "b": "b"}
+        assert second_dict == {"a": "A", "c": "c"}
 
-        with pytest.raises(TypeError):
-            first_dict | second_dict
+    def test_union_operator_merge_with_dict(self):
+        first_dict = dict({"a": "a", "b": "b"})
+        second_dict = immutabledict({"a": "A", "c": "c"})
+        merged_dict = first_dict | second_dict
+        assert isinstance(merged_dict, dict)
+        assert merged_dict == {
+            "a": "A",
+            "b": "b",
+            "c": "c",
+        }
+        assert first_dict == {"a": "a", "b": "b"}
+        assert second_dict == {"a": "A", "c": "c"}
+
+        first_dict = immutabledict({"a": "a", "b": "b"})
+        second_dict = dict({"a": "A", "c": "c"})
+        merged_dict = first_dict | second_dict
+        assert isinstance(merged_dict, immutabledict)
+        assert merged_dict == {
+            "a": "A",
+            "b": "b",
+            "c": "c",
+        }
+        assert first_dict == {"a": "a", "b": "b"}
+        assert second_dict == {"a": "A", "c": "c"}
 
     def test_union_operator_update(self):
-        first_dict = immutabledict({"a": "value", "b": "other_value"})
-        second_dict = immutabledict({"a": "value", "b": "other_value"})
+        first_dict = immutabledict({"a": "a", "b": "b"})
+        second_dict = immutabledict({"a": "A", "c": "c"})
 
         with pytest.raises(TypeError):
             first_dict |= second_dict
+
+    def test_union_operator_update_with_dict(self):
+        first_dict = dict({"a": "a", "b": "b"})
+        second_dict = immutabledict({"a": "A", "c": "c"})
+
+        first_dict |= second_dict
+        assert isinstance(first_dict, dict)
+        assert first_dict == {
+            "a": "A",
+            "b": "b",
+            "c": "c",
+        }
+        assert second_dict == {"a": "A", "c": "c"}
+
+        first_dict = immutabledict({"a": "a", "b": "b"})
+        second_dict = dict({"a": "A", "c": "c"})
+
+        with pytest.raises(TypeError):
+            first_dict |= second_dict
+        assert isinstance(first_dict, immutabledict)
+        assert first_dict == {"a": "a", "b": "b"}
+        assert second_dict == {"a": "A", "c": "c"}
 
 
 class ImmutableOrderedDict:


### PR DESCRIPTION
With this commit, immutabledict supports union operators with dict like

```python
f = immutabledict({"a": "a", "b": "b"})
s = immutabledict({"a": "A", "c": "c"})
assert f | s == {"a": "A", "b": "b", "c": "c"}
```

Note that `|=` operator is not supported while it's immutable.

https://www.python.org/dev/peps/pep-0584/