### PR TITLE
Add 'fromnested()' classmethod to convert nested dict to nested immutabledict

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -16,6 +16,20 @@ class immutabledict(Mapping):
     def fromkeys(cls, seq, value=None, *args, **kwargs):
         return cls(dict.fromkeys(seq, value, *args, **kwargs))
 
+    @classmethod
+    def fromnested(cls, mapping):
+        """Create immutabledict from nested mapping"""
+
+        def inner(value):
+            if isinstance(value, dict):
+                return cls({k: inner(v) for k, v in value.items()})
+            elif isinstance(value, (list, tuple)):
+                return [inner(v) for v in value]
+            else:
+                return value
+
+        return inner(mapping)
+
     def __init__(self, *args, **kwargs):
         self._dict = self.dict_cls(*args, **kwargs)
         self._hash = None

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -15,6 +15,57 @@ class TestImmutableDict:
         assert "b" in immutable_dict
         assert "c" in immutable_dict
 
+    def test_from_nested(self):
+        nested = {
+            "a": {
+                "a": {
+                    "a": {},
+                    "b": [],
+                    "c": "c",
+                },
+                "b": [
+                    {"a": "a"},
+                    ["b"],
+                    "c",
+                ],
+                "c": "c",
+            },
+            "b": [
+                {"a": "a"},
+                ["b"],
+                "c",
+            ],
+            "c": "c",
+        }
+        value = immutabledict.fromnested(nested)
+        assert value == {
+            "a": {
+                "a": {
+                    "a": {},
+                    "b": [],
+                    "c": "c",
+                },
+                "b": [
+                    {"a": "a"},
+                    ["b"],
+                    "c",
+                ],
+                "c": "c",
+            },
+            "b": [
+                {"a": "a"},
+                ["b"],
+                "c",
+            ],
+            "c": "c",
+        }
+        assert isinstance(value, immutabledict)
+        assert isinstance(value["a"], immutabledict)
+        assert isinstance(value["a"]["a"], immutabledict)
+        assert isinstance(value["a"]["a"]["a"], immutabledict)
+        assert isinstance(value["a"]["b"][0], immutabledict)
+        assert isinstance(value["b"][0], immutabledict)
+
     def test_init_and_compare(self):
         normal_dict = {"a": "value", "b": "other_value"}
         immutable_dict = immutabledict(normal_dict)


### PR DESCRIPTION
With this commit, users can convert nested dict to immutabledict by calling `fromnested()` like:

```python
nested = {
    "a": {
        "a": {
            "a": {},
            "b": [],
            "c": "c",
        },
        "b": [
            {"a": "a"},
            ["b"],
            "c",
        ],
        "c": "c",
    },
    "b": [
        {"a": "a"},
        ["b"],
        "c",
    ],
    "c": "c",
}
value = immutabledict.fromnested(nested)
```