### PR TITLE
Fix type annotation on keyword argument in copy(**add_or_replace)

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -45,7 +45,7 @@ class immutabledict(Mapping[_K, _V]):
     def __contains__(self, key: object) -> bool:
         return key in self._dict
 
-    def copy(self, **add_or_replace: Dict[_K, _V]) -> "immutabledict[_K, _V]":
+    def copy(self, **add_or_replace: _V) -> "immutabledict[_K, _V]":
         return self.__class__(self, **add_or_replace)
 
     def __iter__(self) -> Iterator[_K]:


### PR DESCRIPTION
Fix type annotation on keyword argument in `copy(**add_or_replace)`

The type annotation for keyword arguments describes the type of the  _value_, not of the kwargs as a whole itself. (See https://www.python.org/dev/peps/pep-0484/#id37)
This is because the keys of a keyword argument paramater is always `str`.

So the signature of of `copy(self, **add_or_replace: Dict[_K, _V])` means "add_or_replace is a keyword arguments parameter whose _values_ are of type `Dict[_K, _V]`", probably not what was intended.

Now it is set to be `**add_or_replace: _V`, which means it can accept keyword arguments of type `_V`

Incidentally, the return type annotation is incorrect if the self `immutabledict` didn't have `Text` keys or a supertype thereof (as now it is going to have `Text` keys in addition to whatever `_K` was), but that is a separate issue.