### PR TITLE
Fix hard-coded class reference in fromkeys()

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -23,7 +23,7 @@ class immutabledict(Mapping[_K, _V]):
     def fromkeys(
         cls, seq: Iterable[_K], value: Optional[_V] = None
     ) -> "immutabledict[_K, _V]":
-        return cls(dict.fromkeys(seq, value))
+        return cls(cls.dict_cls.fromkeys(seq, value))
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._dict = self.dict_cls(*args, **kwargs)


### PR DESCRIPTION
If you use ImmutableOrderedDict.fromkeys() or any other custo subclass that overrides the `dict_cls`, it will construct a regular dict and not an ordered dict since the `fromkeys()` function hardcodes `dict` instead of the class's `dict_cls`. This PR fixes that