### PR TITLE
Adds covariant true to key type

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Type, TypeV
 __version__ = "2.2.5"
 
 _K = TypeVar("_K")
-_V = TypeVar("_V")
+_V = TypeVar("_V", covariant=True)
 
 
 class immutabledict(Mapping[_K, _V]):
@@ -34,9 +34,6 @@ class immutabledict(Mapping[_K, _V]):
 
     def __contains__(self, key: object) -> bool:
         return key in self._dict
-
-    def copy(self, **add_or_replace: _V) -> immutabledict[_K, _V]:
-        return self.__class__(self, **add_or_replace)
 
     def __iter__(self) -> Iterator[_K]:
         return iter(self._dict)

--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -35,6 +35,9 @@ class immutabledict(Mapping[_K, _V]):
     def __contains__(self, key: object) -> bool:
         return key in self._dict
 
+    def copy(self) -> immutabledict[_K, _V]:
+        return self.__class__(self)
+
     def __iter__(self) -> Iterator[_K]:
         return iter(self._dict)
 

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -12,13 +12,6 @@ class TestImmutableDict:
         with pytest.raises(AttributeError):
             immutabledict().setitem("key", "value")
 
-    def test_copy(self):
-        original = immutabledict({"a": "value"})
-        copy = original.copy()
-        assert original == copy
-        assert id(original) != id(copy)
-
-
     def test_from_keys(self):
         keys = ("a", "b", "c")
         immutable_dict = immutabledict.fromkeys(keys)
@@ -47,6 +40,12 @@ class TestImmutableDict:
     def test_contains_not_existing(self):
         immutable_dict = immutabledict({"a": "value"})
         assert "b" not in immutable_dict
+
+    def test_copy(self):
+        original = immutabledict({"a": "value"})
+        copy = original.copy()
+        assert original == copy
+        assert id(original) != id(copy)
 
     def test_iter(self):
         immutable_dict = immutabledict({"a": "value", "b": "other_value"})

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -4,6 +4,10 @@ from immutabledict import ImmutableOrderedDict, immutabledict
 
 
 class TestImmutableDict:
+    def test_covariance(self):
+        assert immutabledict.__parameters__[0].__covariant__ is False
+        assert immutabledict.__parameters__[1].__covariant__ is True
+
     def test_cannot_assign_value(self):
         with pytest.raises(AttributeError):
             immutabledict().setitem("key", "value")
@@ -36,11 +40,6 @@ class TestImmutableDict:
     def test_contains_not_existing(self):
         immutable_dict = immutabledict({"a": "value"})
         assert "b" not in immutable_dict
-
-    def test_copy(self):
-        original = immutabledict({"a": "value"})
-        copy = original.copy()
-        assert original == copy
 
     def test_iter(self):
         immutable_dict = immutabledict({"a": "value", "b": "other_value"})

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -12,6 +12,13 @@ class TestImmutableDict:
         with pytest.raises(AttributeError):
             immutabledict().setitem("key", "value")
 
+    def test_copy(self):
+        original = immutabledict({"a": "value"})
+        copy = original.copy()
+        assert original == copy
+        assert id(original) != id(copy)
+
+
     def test_from_keys(self):
         keys = ("a", "b", "c")
         immutable_dict = immutabledict.fromkeys(keys)


### PR DESCRIPTION
Adds covariant true to key
This will allow this class to behave the same way that other immutable containers do.
If approved, this will close out this issue: https://github.com/corenting/immutabledict/issues/243
One should probably make this a major release as adding covariant probably makes this a breaking change. Typing experts please weigh in if you see this.