### PR TITLE
add explicit items()/keys()/values() methods

### DIFF
--- a/immutabledict/__init__.py
+++ b/immutabledict/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Type, TypeVar
+from typing import Any, Dict, ItemsView, Iterable, Iterator, Mapping, Optional, Type, TypeVar, ValuesView, KeysView
 
 __version__ = "3.0.0"
 
@@ -72,6 +72,15 @@ class immutabledict(Mapping[_K, _V]):
 
     def __ior__(self, other: Any) -> immutabledict[_K, _V]:
         raise TypeError(f"'{self.__class__.__name__}' object is not mutable")
+
+    def items(self) -> ItemsView[_K, _V]:
+        return self._dict.items()
+
+    def keys(self) -> KeysView[_K]:
+        return self._dict.keys()
+
+    def values(self) -> ValuesView[_V]:
+        return self._dict.values()
 
 
 class ImmutableOrderedDict(immutabledict[_K, _V]):

--- a/tests/test_immutabledict.py
+++ b/tests/test_immutabledict.py
@@ -185,6 +185,19 @@ class TestImmutableDict:
         assert first_dict == {"a": "a", "b": "b"}
         assert second_dict == {"a": "A", "c": "c"}
 
+    def test_performance(self) -> None:
+        from timeit import timeit
+        time_standard = timeit(
+            "for k, v in d.items(): s += 1", number=3,
+            setup="s=0; d = {i:i for i in range(1000000)}")
+
+        time_immutable = timeit(
+            "for k, v in d.items(): s += 1", globals=globals(), number=3,
+            setup="s=0; d = immutabledict({i:i for i in range(1000000)})")
+
+        assert time_immutable < 1.2 * time_standard
+
+
 
 class TestImmutableOrderedDict:
     def test_ordered(self) -> None:


### PR DESCRIPTION
This appears to speed up these operations substantially.

With this small benchmark:

```python
import immutabledict
import timeit

d_init = {i:i for i in range(10000000)}

d = dict(d_init)
print("dict", timeit.timeit(
    "for k, v in d.items(): s += 1", globals=globals(), number=3, setup="s=0"))

d = immutabledict.immutabledict(d_init)
print("immutabledict", timeit.timeit(
    "for k, v in d.items(): s += 1", globals=globals(), number=3, setup="s=0"))
```

Before:
```
$ python dictspeed.py
dict 0.5598837919533253
immutabledict 2.162265417049639
```

After:
```
$ python dictspeed.py
dict 0.5607237920630723
immutabledict 0.5689269590564072
```

The added test fails without this PR.